### PR TITLE
Omit unnecessary values from result

### DIFF
--- a/src/object.test.ts
+++ b/src/object.test.ts
@@ -2,7 +2,7 @@ import { jsonDateParser } from 'json-date-parser';
 import { isDate } from './date';
 import { asNumber, isNumber } from './number';
 import { asObject, isObject, maybeAsObject, maybeObject } from './object';
-import { asString, isString } from './string';
+import { asString, isString, maybeString } from './string';
 import { expectIssue, expectSuccess, expectValue, runTests } from './test-helpers';
 import { isIssue } from './types';
 
@@ -81,6 +81,29 @@ describe('isObject', () => {
     expectIssue(fut, { a: 47, b: 'asd', c: 234 }, 'unexpected-property', ['c']);
     expectIssue(fut, {}, 'not-defined', ['a']);
     expectIssue(fut, {}, 'not-defined', ['b']);
+  });
+
+  it('will handle optional property', () => {
+    const fut = isObject<{ a: number, b?: string }>({
+      a: isNumber(),
+      b: maybeString(),
+    });
+    expectIssue(fut, {}, 'not-defined', ['a']);
+    expectIssue(fut, { b: 'asd' }, 'not-defined', ['a']);
+    {
+      const result = expectSuccess(fut, { a: 42 });
+      expect(result.value).not.toHaveProperty('b');
+    }
+    {
+      const result = expectSuccess(fut, { a: 42, b: undefined });
+      expect(result.value).toHaveProperty('b');
+      expect(result.value.b).toEqual(undefined);
+    }
+    {
+      const result = expectSuccess(fut, { a: 42, b: null });
+      expect(result.value).toHaveProperty('b');
+      expect(result.value.b).toEqual(undefined);
+    }
   });
 
   it('will error on unexpected properties', () => {

--- a/src/object.ts
+++ b/src/object.ts
@@ -64,21 +64,20 @@ class Generic<T extends { [key: string]: any; }> {
     if (!options) return next(value);
 
     let coerced = { ...value };
-    if (options.contract) {
-      if (options.stripExtraProperties) {
-        const allowedProperties = new Set(Object.keys(options.contract));
-        (Object.keys(coerced) as (keyof T)[]).forEach((key) => {
-          if (allowedProperties.has(key as string)) return;
-          delete coerced[key];
-        });
-      }
-      const result = this.process(options.contract, coerced);
-      if (isIssue(result)) {
-        return result;
-      }
-      if (result) {
-        coerced = result.value;
-      }
+    if (!options.contract) return next(coerced);
+
+    if (options.stripExtraProperties) {
+      const allowedProperties = new Set(Object.keys(options.contract));
+      (Object.keys(coerced) as (keyof T)[]).forEach((key) => {
+        if (allowedProperties.has(key as string)) return;
+        delete coerced[key];
+      });
+    }
+    const result = this.process(options.contract, coerced);
+    if (isIssue(result)) return result;
+
+    if (result) {
+      coerced = result.value;
     }
     return next(coerced);
   }

--- a/src/object.ts
+++ b/src/object.ts
@@ -51,6 +51,8 @@ class Generic<T extends { [key: string]: any; }> {
         });
         return;
       }
+      if (childResult.value === undefined && !(key in target)) return;
+
       if (childResult) {
         output[key] = childResult.value;
       } else {

--- a/src/test-helpers.ts
+++ b/src/test-helpers.ts
@@ -42,7 +42,6 @@ export const runTests = <T>(fut: ValueProcessor<T>, ...tests: Array<TestDefiniti
 export const expectIssue = <T>(fut: ValueProcessor<T>, value: unknown, reason: string, path: Path[] = []): void => {
   const result = fut.process(value);
   if (!isIssue(result)) {
-    // eslint-disable-next-line no-undef
     fail('no issue');
   }
   expect(result.issues).toEqual(
@@ -59,7 +58,6 @@ export const expectSuccess = <T>(fut: ValueProcessor<T>, value: unknown): void =
   const result = fut.process(value);
   expect(result).toBeDefined();
   if (isIssue(result)) {
-    // eslint-disable-next-line no-undef
     fail(`Unexpected issue: ${JSON.stringify(result)}`);
   }
 };
@@ -68,7 +66,6 @@ export const expectValue = <T>(fut: ValueProcessor<T>, value: unknown, coerced: 
   const result = fut.process(value);
   expect(result).toBeDefined();
   if (isIssue(result)) {
-    // eslint-disable-next-line no-undef
     fail(`Unexpected issue: ${JSON.stringify(result)}`);
   }
   if (result) {

--- a/src/test-helpers.ts
+++ b/src/test-helpers.ts
@@ -1,4 +1,4 @@
-import { isIssue, Path, ValueProcessor } from './types';
+import { isIssue, Path, ValueProcessor, ValueResult } from './types';
 
 export interface TestIssue {
   path?: Path[];
@@ -54,12 +54,13 @@ export const expectIssue = <T>(fut: ValueProcessor<T>, value: unknown, reason: s
   );
 };
 
-export const expectSuccess = <T>(fut: ValueProcessor<T>, value: unknown): void => {
+export const expectSuccess = <T>(fut: ValueProcessor<T>, value: unknown): ValueResult<T> => {
   const result = fut.process(value);
   expect(result).toBeDefined();
   if (isIssue(result)) {
     fail(`Unexpected issue: ${JSON.stringify(result)}`);
   }
+  return result;
 };
 
 export const expectValue = <T>(fut: ValueProcessor<T>, value: unknown, coerced: T): void => {


### PR DESCRIPTION
Keys that are not present in the input should not be part of the result if they are optional anyway.